### PR TITLE
Update dependencies to work with Leiningen out of the box

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject compojure-example "0.1.0"
   :description "Example Compojure project"
   :dependencies [[org.clojure/clojure "1.2.0"]
-                 [compojure "0.6.0-RC4"]
-                 [hiccup "0.3.4"]]
-  :dev-dependencies [[lein-ring "0.3.2"]]
+                 [compojure "0.6.4"]
+                 [hiccup "0.3.6"]]
+  :dev-dependencies [[lein-ring "0.4.5"]]
   :ring {:handler compojure.example.routes/app})


### PR DESCRIPTION
It may be that the only necessary change was the lein-ring version, but while I was here....
