### PR TITLE
Updated dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pom.xml
 *.war
 lib
 classes
+target

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject compojure-example "0.1.0"
   :description "Example Compojure project"
-  :dependencies [[org.clojure/clojure "1.2.1"]
-                 [compojure "1.0.0"]
-                 [hiccup "0.3.7"]]
-  :dev-dependencies [[lein-ring "0.5.0"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [compojure "1.1.1"]
+                 [hiccup "1.0.0"]]
+  :plugins [[lein-ring "0.7.1"]]
   :ring {:handler compojure.example.routes/app})

--- a/src/compojure/example/views.clj
+++ b/src/compojure/example/views.clj
@@ -1,5 +1,5 @@
 (ns compojure.example.views
-  (:use [hiccup core page-helpers]))
+  (:use [hiccup core page]))
 
 (defn index-page []
   (html5


### PR DESCRIPTION
This lets the example project work out of the box on Leinengen 1.7.1 and Leiningen 2.0.0-preview7.
