### PR TITLE
replace compojure.handler with ring.defaults

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,8 @@
 (defproject compojure-example "0.1.0"
   :description "Example Compojure project"
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [compojure "1.1.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [compojure "1.5.2"]
+                 [ring/ring-defaults "0.2.1"]
                  [hiccup "1.0.0"]]
-  :plugins [[lein-ring "0.7.1"]]
+  :plugins [[lein-ring "0.9.7"]]
   :ring {:handler compojure.example.routes/app})

--- a/src/compojure/example/routes.clj
+++ b/src/compojure/example/routes.clj
@@ -3,8 +3,7 @@
         compojure.example.views
         [hiccup.middleware :only (wrap-base-url)])
   (:require [compojure.route :as route]
-            [compojure.handler :as handler]
-            [compojure.response :as response]))
+            [ring.middleware.defaults :refer :all]))
 
 (defroutes main-routes
   (GET "/" [] (index-page))
@@ -12,5 +11,5 @@
   (route/not-found "Page not found"))
 
 (def app
-  (-> (handler/site main-routes)
+  (-> (wrap-defaults main-routes site-defaults)
       (wrap-base-url)))


### PR DESCRIPTION
This PR updates the example to use `ring.middleware.defaults` instead of `compojure.handler`, to avoid the issue mention in: 
https://github.com/ring-clojure/ring/issues/251

Also update:
- clojure
- compojure
- lein-ring